### PR TITLE
ci: add jscpd configuration to unblock lint-workflows

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,4 @@
+{
+  "threshold": 2,
+  "ignore": ["**/.github/workflows/**"]
+}


### PR DESCRIPTION
## Problem

The required `lint-workflows / lint workflows` check fails with:

```
ERROR: jscpd found too many duplicates over threshold
```

super-linter runs JSCPD across the **entire workspace**, ignoring the
`FILTER_REGEX_INCLUDE` that the `lint-workflows` reusable workflow sets. With no
repo-local config it falls back to super-linter's default
(`/action/lib/.automation/.jscpd.json`, `threshold: 0`), so *any* duplication
fails the build.

Because the check is required and branch protection is `strict`, this blocks
otherwise-green Dependabot PRs — currently #237.

## Fix

Add `.github/linters/.jscpd.json` (super-linter's `LINTER_RULES_PATH`) with a 2%
threshold, ignoring the org-standard workflow boilerplate — the
`add-to-project-*` / `add-labels-standardized` / build-failure-notification
blocks are duplicated by design and cannot be de-duplicated.


Copy/paste detection still guards real source.

## Verification

Reproduced locally with `jscpd@5.0.10` (the version super-linter ships) using
this config against the repo root: exits 0.

---

Resolves #237